### PR TITLE
bugfix for correct injection of provider in minified file

### DIFF
--- a/src/angular-mocks-async.js
+++ b/src/angular-mocks-async.js
@@ -209,11 +209,11 @@
 		
 	}
 	
-	httpMock.config( function( $provide ) {
+	httpMock.config(['$provide',function( $provide ) {
 		
 		$provide.decorator( '$httpBackend', angular.mock.$HttpBackendAsyncDecorator );
 		
-	});
+	}]);
 	
 	
 })( angular );


### PR DESCRIPTION
Hello , 
I encountered an error with the minified version of your module (Failed to instantiate module ngMockE2EAsync due to: Error: [$injector:unpr] Unknown provider: e).

I found the origin of this error, in the config module, because the name of the module to inject was missing.

Here's the PR to fix it.

Thanks for your work.